### PR TITLE
Fix PRAGMA execution with SQLAlchemy

### DIFF
--- a/services/db.py
+++ b/services/db.py
@@ -6,6 +6,7 @@ import schedule
 import time
 from threading import Thread
 from sqlmodel import create_engine, Session, SQLModel, select
+from sqlalchemy import text
 
 from models import Correction, Log, User
 
@@ -17,7 +18,7 @@ def init_db():
     """Create tables and set WAL"""
     SQLModel.metadata.create_all(engine)
     with engine.connect() as conn:
-        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute(text("PRAGMA journal_mode=WAL;"))
 
     schedule.every().day.at("03:00").do(archive_old)
     Thread(target=_run_scheduler, daemon=True).start()


### PR DESCRIPTION
## Summary
- set WAL journal mode using `text()` to avoid ObjectNotExecutableError

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685809b9488c832ba99ea2f3ead49671