### PR TITLE
Fix config defaults and count queries

### DIFF
--- a/app.py
+++ b/app.py
@@ -140,12 +140,16 @@ if st.sidebar.button("退出登录"):
     rerun()
 
 
-cfg = {k: float(v) for k, v in get_all().items() if k in {'alpha','beta','gamma'}}
+# 默认权重设置
+cfg = get_all()
+alpha_init = float(cfg.get('alpha', 0.4))
+beta_init = float(cfg.get('beta', 0.4))
+gamma_init = float(cfg.get('gamma', 0.1))
 # 在侧边栏放置纠错参数
 st.sidebar.header("纠错参数设置")
-alpha = st.sidebar.slider("Alpha (模型得分权重)", 0.0, 1.0, cfg['alpha'], 0.05)
-beta  = st.sidebar.slider("Beta (拼音相似度权重)", 0.0, 1.0, cfg['beta'], 0.05)
-gamma = st.sidebar.slider("Gamma (字形相似度权重)", 0.0, 1.0, cfg['gamma'], 0.05)
+alpha = st.sidebar.slider("Alpha (模型得分权重)", 0.0, 1.0, alpha_init, 0.05)
+beta  = st.sidebar.slider("Beta (拼音相似度权重)", 0.0, 1.0, beta_init, 0.05)
+gamma = st.sidebar.slider("Gamma (字形相似度权重)", 0.0, 1.0, gamma_init, 0.05)
 legal_only = st.sidebar.checkbox("仅限法律术语", value=False)
 debug_mode = st.sidebar.checkbox("显示候选词细节", value=False)
 if st.sidebar.button("保存参数"):

--- a/migrations/001_initial.py
+++ b/migrations/001_initial.py
@@ -1,11 +1,23 @@
 """Initial database creation"""
-from sqlmodel import SQLModel
+from sqlmodel import SQLModel, Session, select
 from models import User, Correction, KVConfig, Log
 from services.db import engine
 
 
 def run():
     SQLModel.metadata.create_all(engine)
+    defaults = {
+        "alpha": "0.4",
+        "beta": "0.4",
+        "gamma": "0.1",
+        "daily_limit": "20",
+    }
+    with Session(engine) as session:
+        for k, v in defaults.items():
+            exists = session.exec(select(KVConfig).where(KVConfig.key == k)).first()
+            if not exists:
+                session.add(KVConfig(key=k, value=v))
+        session.commit()
 
 
 if __name__ == "__main__":

--- a/pages/logs.py
+++ b/pages/logs.py
@@ -5,13 +5,14 @@ from services.auth import log_action
 from services.db import get_session
 from models import Log
 from sqlmodel import select
+from sqlalchemy import func
 
 st.title("日志管理")
 
 page = st.number_input("页码", min_value=1, step=1, value=1)
 page_size = 20
 with get_session() as session:
-    total = session.exec(select(Log).count()).one()
+    total = session.exec(select(func.count()).select_from(Log)).one()
     logs = session.exec(select(Log).order_by(Log.id.desc()).offset((page-1)*page_size).limit(page_size)).all()
 
 df = pd.DataFrame([l.dict() for l in logs])

--- a/services/correction.py
+++ b/services/correction.py
@@ -1,6 +1,7 @@
 from difflib import ndiff
 import json
 from sqlmodel import select
+from sqlalchemy import func
 from models import Correction
 from .db import get_session
 
@@ -29,5 +30,5 @@ def load_history(username: str | None, start: str | None, end: str | None, offse
             stmt = stmt.where(Correction.ts <= end)
         stmt = stmt.order_by(Correction.ts.desc()).offset(offset).limit(limit)
         rows = session.exec(stmt).all()
-        total = session.exec(select(Correction).count()).one()
+        total = session.exec(select(func.count()).select_from(Correction)).one()
         return rows, total


### PR DESCRIPTION
## Summary
- provide default alpha/beta/gamma values when settings not present
- use SQL `func.count()` when counting rows
- seed default settings during DB init

## Testing
- `pip install -q -r requirements.txt` *(with SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL)*
- `python -m py_compile app.py pages/logs.py services/correction.py migrations/001_initial.py`


------
https://chatgpt.com/codex/tasks/task_e_68580ad4c78c832ba6103ecdcfd82f99