### PR TITLE
Fix settings error and improve UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,8 +165,8 @@ tab_single, tab_batch = st.tabs(["单句纠错", "批量纠错"])
 # 4. 单句纠错
 # ===============================
 with tab_single:
-    default_text = st.session_state.pop('input_text', '')
-    input_text = st.text_area("请输入待纠错的中文句子：", value=default_text, height=120)
+    default_text = st.session_state.get('input_text', '')
+    input_text = st.text_area("请输入待纠错的中文句子：", key="input_text", value=default_text, height=120)
     if st.button("开始纠错", key="single_correct"):
         if not input_text.strip():
             st.warning("请输入文本内容。")

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -8,12 +8,18 @@ st.title("系统设置")
 cfg = get_all()
 
 for k, v in cfg.items():
+    try:
+        num_v = float(v)
+    except ValueError:
+        st.text_input(k, value=v, disabled=True)
+        continue
+
     if st.session_state.get('role') == 'admin':
-        new_v = st.number_input(k, value=float(v), min_value=0.0, max_value=1.0, step=0.05)
-        if new_v != float(v):
+        new_v = st.number_input(k, value=num_v, min_value=0.0, max_value=1.0, step=0.05)
+        if new_v != num_v:
             save(k, str(new_v))
             st.toast("已保存")
     else:
-        st.number_input(k, value=float(v), disabled=True)
+        st.number_input(k, value=num_v, disabled=True)
 
 log_action(st.session_state.get('user',''), 'view_settings', '')

--- a/text_correction_tool.py
+++ b/text_correction_tool.py
@@ -145,10 +145,10 @@ class TextCorrectionTool:
                     if info["flag"]:
                         valid_candidates.append(cand)
 
-                # 记录分支
-                branch = "Precision" if valid_candidates else "General"
+                # 记录分支，使用中文描述
+                branch = "精确" if valid_candidates else "通用"
                 if legal_only:
-                    branch = "Precision"
+                    branch = "精确"
                 branch_history.append(branch)
 
                 # 强制精确分支且没有合法候选，则直接回填原字符


### PR DESCRIPTION
## Summary
- handle non-numeric config values in settings page
- keep loaded history text when correcting
- display branch history in Chinese

## Testing
- `python -m py_compile pages/settings.py text_correction_tool.py app.py`
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6858100931e0832bab1039ace3b669e8