### PR TITLE
修复日志保存 user 为空导致异常

### DIFF
--- a/services/auth.py
+++ b/services/auth.py
@@ -41,9 +41,11 @@ def verify(username: str, password: str) -> tuple[bool, str]:
         return False, ""
 
 
-def log_action(user: str, action: str, payload: str = ""):
+def log_action(user: str | None, action: str, payload: str = ""):
+    """记录用户操作日志，如果 user 为空则记为 anonymous"""
+    username = user or "anonymous"
     with get_session() as session:
-        session.add(Log(user=user, action=action, payload=payload))
+        session.add(Log(user=username, action=action, payload=payload))
         session.commit()
 
 


### PR DESCRIPTION
## 变更摘要
- `log_action` 现在支持 `user` 为 `None`，缺省记录为 `anonymous`

## 测试结果
- `pytest -q` 运行通过（无测试）

------
https://chatgpt.com/codex/tasks/task_e_68581b89a1ec832b8f85d16d0bd6ccac